### PR TITLE
Added support to use XML configuration for log4j

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -22,7 +22,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/pom.xml
+++ b/pom.xml
@@ -3,13 +3,36 @@
 
 	<groupId>net.mihai-nita</groupId>
 	<artifactId>color-loggers</artifactId>
-	<version>1.0.1</version>
+	<version>1.0.2-SNAPSHOT</version>
 	<name>Color Loggers</name>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
+	<build>
+	  <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+		<version>2.2.1</version>
+                <configuration>
+                    <includePom>true</includePom>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>jar</goal>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+	  </plugins>
+	</build>
+	
 	<dependencies>
 		<dependency>
 			<groupId>log4j</groupId>
@@ -20,6 +43,11 @@
 			<groupId>org.fusesource.jansi</groupId>
 			<artifactId>jansi</artifactId>
 			<version>1.9</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-lang</groupId>
+			<artifactId>commons-lang</artifactId>
+			<version>2.6</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/com/colorlog/log4j/BaseColorConsoleAppender.java
+++ b/src/main/java/com/colorlog/log4j/BaseColorConsoleAppender.java
@@ -3,6 +3,7 @@ package com.colorlog.log4j;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.log4j.ConsoleAppender;
 import org.apache.log4j.EnhancedPatternLayout;
 import org.apache.log4j.Layout;
@@ -38,27 +39,27 @@ public abstract class BaseColorConsoleAppender extends ConsoleAppender {
 	}
 
 	public void setFatalColour(String value) {
-		levelToColor.put(Level.FATAL, value);
+		levelToColor.put(Level.FATAL, StringEscapeUtils.unescapeJava(value));
 	}
 
 	public void setErrorColour(String value) {
-		levelToColor.put(Level.ERROR, value);
+		levelToColor.put(Level.ERROR, StringEscapeUtils.unescapeJava(value));
 	}
 
 	public void setWarnColour(String value) {
-		levelToColor.put(Level.WARN, value);
+		levelToColor.put(Level.WARN, StringEscapeUtils.unescapeJava(value));
 	}
 
 	public void setInfoColour(String value) {
-		levelToColor.put(Level.INFO, value);
+		levelToColor.put(Level.INFO, StringEscapeUtils.unescapeJava(value));
 	}
 
 	public void setDebugColour(String value) {
-		levelToColor.put(Level.DEBUG, value);
+		levelToColor.put(Level.DEBUG, StringEscapeUtils.unescapeJava(value));
 	}
 
 	public void setTraceColour(String value) {
-		levelToColor.put(Level.TRACE, value);
+		levelToColor.put(Level.TRACE, StringEscapeUtils.unescapeJava(value));
 	}
 
 	protected String getColour(Level level) {

--- a/src/test/java/com/colorlog/log4j/ColorLogXmlTest.java
+++ b/src/test/java/com/colorlog/log4j/ColorLogXmlTest.java
@@ -1,0 +1,57 @@
+package com.colorlog.log4j;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.apache.log4j.xml.DOMConfigurator;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+
+/**
+ * TODO:Class description.
+ *
+ * @author chakuht0
+ */
+public class ColorLogXmlTest {
+
+	public static String getTargetDir() {
+		URL url = ColorLogXmlTest.class.getResource("/");
+		if (null == url)
+			return ".";
+
+		try {
+			return url.toURI().getPath();
+		} catch (URISyntaxException e) {
+		}
+
+		return ".";
+	}
+	
+	
+	@Test
+	public void testColorLogging() {
+		
+		org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger("log-log4j");
+		String root = getTargetDir();
+
+		DOMConfigurator.configure(root + "log4j/log4j.xml");
+		
+		System.out.println("===================================================");
+		System.out.println("===== Color logger - log4j - XML configuration ====");
+		System.out.println("===================================================");
+
+		logger.fatal("fatal with XML");
+		logger.error("error with XML");
+		logger.warn("warn with XML");
+		logger.info("info with XML");
+		logger.debug("debug with XML");
+		logger.trace("trace with XML");
+	}
+	
+	
+	public static void main(String[] argv) {
+		JUnitCore.runClasses(new Class[] { ColorLogXmlTest.class });
+	}
+}
+

--- a/src/test/resources/log4j/log4j.xml
+++ b/src/test/resources/log4j/log4j.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<!--
+******************************************************************************
+* Log4j Configuration
+*
+* Logging levels (higest to lowest):
+*   off, fatal, error, warn, info, debug, all
+* A logging request is enabled if its level is
+* higher than or equal to the level of its logger.
+******************************************************************************
+-->
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+
+  <!-- ******************************************************************* -->
+  <!-- ConsoleAppender                                                     -->
+  <!-- ******************************************************************* -->
+  <appender name="A2" class="com.colorlog.log4j.AnsiColorConsoleAppender" >
+    
+    <param name="WarnColour" value="\\u001b[0;33m" />
+    <param name="InfoColour" value="\\u001b[22;32m" />
+    
+    <layout class="org.apache.log4j.EnhancedPatternLayout">
+      <param name="ConversionPattern" value="Ansi > %-5p: %c{2} [%t] - %m%n"/>
+    </layout>
+    
+  </appender>
+
+  <appender name="A3" class="com.colorlog.log4j.JAnsiColorConsoleAppender" >
+    
+    <param name="WarnColour" value="\\u001b[0;33m" />
+    <param name="InfoColour" value="\\u001b[22;32m" />
+    <!-- 
+    <param name="PassThrough" value="true" />
+    <param name="Strip" value="true" />
+    -->
+    
+    <layout class="org.apache.log4j.EnhancedPatternLayout">
+      <param name="ConversionPattern" value="Jansi> %-5p: %c{2} [%t] - %m%n"/>
+    </layout>
+    
+  </appender>
+
+  <!-- ******************************************************************* -->
+  <!-- Root Logger                                                         -->
+  <!-- ******************************************************************* -->
+  <root>
+    <level value="trace"/>
+    <appender-ref ref="A2"/>
+    <appender-ref ref="A3"/>
+  </root>
+
+</log4j:configuration>


### PR DESCRIPTION
Added support to use XML configuration for log4j. Must use double
backslash to start the escape sequence because DomConfigurator removes
first backslash.
