### PR TITLE
* Numerous Fixes for Color:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,15 @@
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<version>3.0</version>
+						<configuration>
+							<source>1.5</source>
+							<target>1.5</target>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
 						<version>1.6</version>
 						<executions>

--- a/src/main/java/com/mihnita/colorlog/jdk/BaseColorConsoleHandler.java
+++ b/src/main/java/com/mihnita/colorlog/jdk/BaseColorConsoleHandler.java
@@ -10,13 +10,13 @@ import java.util.logging.LogRecord;
 public abstract class BaseColorConsoleHandler extends ConsoleHandler {
     protected static final String COLOR_RESET   = "\u001b[0m";
 
-    protected static final String COLOR_SEVERE  = "\u001b[91m";
+    protected static final String COLOR_SEVERE  = "\u001b[97;41m";
     protected static final String COLOR_WARNING = "\u001b[93m";
     protected static final String COLOR_INFO    = "\u001b[32m";
-    protected static final String COLOR_CONFIG  = "\u001b[94m";
+    protected static final String COLOR_CONFIG  = "\u001b[92m";
     protected static final String COLOR_FINE    = "\u001b[36m";
-    protected static final String COLOR_FINER   = "\u001b[35m";
-    protected static final String COLOR_FINEST  = "\u001b[90m";
+    protected static final String COLOR_FINER   = "\u001b[34m";
+    protected static final String COLOR_FINEST  = "\u001b[95m";
 
     String logRecordToString(LogRecord record) {
         Formatter f = getFormatter();

--- a/src/main/java/com/mihnita/colorlog/log4j/BaseColorConsoleAppender.java
+++ b/src/main/java/com/mihnita/colorlog/log4j/BaseColorConsoleAppender.java
@@ -24,9 +24,9 @@ public abstract class BaseColorConsoleAppender extends ConsoleAppender {
         levelToColor.put(Level.FATAL, "\u001b[97;41m");
         levelToColor.put(Level.ERROR, "\u001b[91m");
         levelToColor.put(Level.WARN,  "\u001b[93m");
-        levelToColor.put(Level.INFO,  "\u001b[22;32m");
-        levelToColor.put(Level.DEBUG, "\u001b[22;36m");
-        levelToColor.put(Level.TRACE, "\u001b[90m");
+        levelToColor.put(Level.INFO,  "\u001b[32m");
+        levelToColor.put(Level.DEBUG, "\u001b[36m");
+        levelToColor.put(Level.TRACE, "\u001b[94m");
     }
 
     public BaseColorConsoleAppender() {

--- a/src/main/java/com/mihnita/colorlog/logback/CustomHighlightingCompositeConverter.java
+++ b/src/main/java/com/mihnita/colorlog/logback/CustomHighlightingCompositeConverter.java
@@ -11,7 +11,7 @@ public class CustomHighlightingCompositeConverter extends ForegroundCompositeCon
     static String warningColor = BOLD + YELLOW_FG;
     static String infoColor    = GREEN_FG;
     static String debugColor   = CYAN_FG;
-    static String traceColor   = BOLD + BLACK_FG;
+    static String traceColor   = BOLD + BLUE_FG;
 
     @Override
     protected String getForegroundColorCode(ILoggingEvent event) {

--- a/src/test/resources/log4jPropColorEsc.properties
+++ b/src/test/resources/log4jPropColorEsc.properties
@@ -14,4 +14,4 @@ log4j.appender.A.layout.ConversionPattern=Ansi> %-5p: %c{2} [%t] - %m%n
 # log4j.appender.A.WarnColour ={esc}[33m
 # log4j.appender.A.InfoColour ={esc}[92m
 # log4j.appender.A.DebugColour={esc}[96m
-# log4j.appender.A.TraceColour={esc}[90m
+# log4j.appender.A.TraceColour={esc}[94m

--- a/src/test/resources/log4jPropColorEscRegion.properties
+++ b/src/test/resources/log4jPropColorEscRegion.properties
@@ -14,4 +14,4 @@ log4j.appender.A.layout.ConversionPattern=AnsiReg> {highlight}%-5p:{/highlight} 
 # log4j.appender.A.WarnColour ={esc}[33m
 # log4j.appender.A.InfoColour ={esc}[92m
 # log4j.appender.A.DebugColour={esc}[96m
-# log4j.appender.A.TraceColour={esc}[90m
+# log4j.appender.A.TraceColour={esc}[94m

--- a/src/test/resources/log4jPropColorJansi.properties
+++ b/src/test/resources/log4jPropColorJansi.properties
@@ -19,4 +19,4 @@ log4j.appender.A.layout.ConversionPattern=Jansi> %-5p: %c{2} [%t] - %m%n
 # log4j.appender.A.WarnColour ={esc}[33m
 # log4j.appender.A.InfoColour ={esc}[92m
 # log4j.appender.A.DebugColour={esc}[96m
-# log4j.appender.A.TraceColour={esc}[90m
+# log4j.appender.A.TraceColour={esc}[94m

--- a/src/test/resources/log4jPropColorJansiRegion.properties
+++ b/src/test/resources/log4jPropColorJansiRegion.properties
@@ -19,4 +19,4 @@ log4j.appender.A.layout.ConversionPattern=JansiReg> {highlight}%-5p:{/highlight}
 # log4j.appender.A.WarnColour ={esc}[33m
 # log4j.appender.A.InfoColour ={esc}[92m
 # log4j.appender.A.DebugColour={esc}[96m
-# log4j.appender.A.TraceColour={esc}[90m
+# log4j.appender.A.TraceColour={esc}[94m

--- a/src/test/resources/log4jXmlColorEsc.xml
+++ b/src/test/resources/log4jXmlColorEsc.xml
@@ -20,7 +20,7 @@
 		<!-- <param name="WarnColour" value="{esc}[33m" /> -->
 		<!-- <param name="InfoColour" value="{esc}[92m" /> -->
 		<!-- <param name="DebugColour" value="{esc}[96m" /> -->
-		<!-- <param name="TraceColour" value="{esc}[90m" /> -->
+		<!-- <param name="TraceColour" value="{esc}[94m" /> -->
 
 		<layout class="org.apache.log4j.EnhancedPatternLayout">
 			<param name="ConversionPattern" value="Ansi> %-5p: %c{2} [%t] - %m%n"/>

--- a/src/test/resources/log4jXmlColorEscRegion.xml
+++ b/src/test/resources/log4jXmlColorEscRegion.xml
@@ -20,7 +20,7 @@
 		<!-- <param name="WarnColour" value="{esc}[33m" /> -->
 		<!-- <param name="InfoColour" value="{esc}[92m" /> -->
 		<!-- <param name="DebugColour" value="{esc}[96m" /> -->
-		<!-- <param name="TraceColour" value="{esc}[90m" /> -->
+		<!-- <param name="TraceColour" value="{esc}[94m" /> -->
 
 		<layout class="org.apache.log4j.EnhancedPatternLayout">
 			<param name="ConversionPattern" value="AnsiReg> {highlight}%-5p:{/highlight} %c{2} [%t] - %m%n"/>

--- a/src/test/resources/log4jXmlColorJansi.xml
+++ b/src/test/resources/log4jXmlColorJansi.xml
@@ -25,7 +25,7 @@
 		<!-- <param name="WarnColour" value="{esc}[33m" /> -->
 		<!-- <param name="InfoColour" value="{esc}[92m" /> -->
 		<!-- <param name="DebugColour" value="{esc}[96m" /> -->
-		<!-- <param name="TraceColour" value="{esc}[90m" /> -->
+		<!-- <param name="TraceColour" value="{esc}[94m" /> -->
 
 		<layout class="org.apache.log4j.EnhancedPatternLayout">
 			<param name="ConversionPattern" value="Jansi> %-5p: %c{2} [%t] - %m%n"/>

--- a/src/test/resources/log4jXmlColorJansiRegion.xml
+++ b/src/test/resources/log4jXmlColorJansiRegion.xml
@@ -25,7 +25,7 @@
 		<!-- <param name="WarnColour" value="{esc}[33m" /> -->
 		<!-- <param name="InfoColour" value="{esc}[92m" /> -->
 		<!-- <param name="DebugColour" value="{esc}[96m" /> -->
-		<!-- <param name="TraceColour" value="{esc}[90m" /> -->
+		<!-- <param name="TraceColour" value="{esc}[94m" /> -->
 
 		<layout class="org.apache.log4j.EnhancedPatternLayout">
 			<param name="ConversionPattern" value="JansiReg> {highlight}%-5p:{/highlight} %c{2} [%t] - %m%n"/>

--- a/src/test/resources/logbackColorEsc.xml
+++ b/src/test/resources/logbackColorEsc.xml
@@ -4,11 +4,11 @@
 		<encoder class="com.mihnita.colorlog.logback.ColorPatternLayoutEncoder">
 			<pattern>%highlight(CustomColors> %-5level: %logger{15} - %msg) %n</pattern>
 			<!--
-			<errorColor>1;31</errorColor>
-			<warningColor>1;33</warningColor>
+			<errorColor>91</errorColor>
+			<warningColor>93</warningColor>
 			<infoColor>32</infoColor>
 			<debugColor>36</debugColor>
-			<traceColor>1;30</traceColor>
+			<traceColor>94</traceColor>
 			-->
 		</encoder>
 		<withJansi>false</withJansi>

--- a/src/test/resources/logbackColorEscRegion.xml
+++ b/src/test/resources/logbackColorEscRegion.xml
@@ -4,11 +4,11 @@
 		<encoder class="com.mihnita.colorlog.logback.ColorPatternLayoutEncoder">
 			<pattern>CustomColorsReg> %highlight(%-5level:) %logger{15} - %msg%n</pattern>
 			<!--
-			<errorColor>1;31</errorColor>
-			<warningColor>1;33</warningColor>
+			<errorColor>91</errorColor>
+			<warningColor>93</warningColor>
 			<infoColor>32</infoColor>
 			<debugColor>36</debugColor>
-			<traceColor>1;30</traceColor>
+			<traceColor>94</traceColor>
 			-->
 		</encoder>
 		<withJansi>false</withJansi>


### PR DESCRIPTION
Hi,

I'm sending you a pull request for the following:

1. The Color Schema now works on Black and White background terminals. White terminals such as xterm as well as traditional black terminals can both display a neutral color such as blue, as opposed to black. 
2. The color scheme is now uniform, JUL is a rainbow now: FINER corresponds to trace, which is blue and FINEST is a violet color which is something more verbose than TRACE. This allows us to have uniform coloring across JUL, LOG4J and SLF4J by default. I've used the 9/3 scheme instead of the old 1;/0; scheme used before.
3. The JAR is now built for 1.5, so it can work on an older VM. This allows me to use it on old legacy projects and given them some beautiful color. 

target/color-loggers-1.0.5.jar/com/mihnita/colorlog/jdk/AnsiColorConsoleHandler.class:  compiled Java class data, version 49.0 (Java 1.5)
target/color-loggers-1.0.5.jar/com/mihnita/colorlog/jdk/BaseColorConsoleHandler.class:  compiled Java class data, version 49.0 (Java 1.5)
target/color-loggers-1.0.5.jar/com/mihnita/colorlog/jdk/JAnsiColorConsoleHandler.class:  compiled Java class data, version 49.0 (Java 1.5)
target/color-loggers-1.0.5.jar/com/mihnita/colorlog/log4j/AnsiColorConsoleAppender.class:  compiled Java class data, version 49.0 (Java 1.5)
target/color-loggers-1.0.5.jar/com/mihnita/colorlog/log4j/BaseColorConsoleAppender.class:  compiled Java class data, version 49.0 (Java 1.5)
target/color-loggers-1.0.5.jar/com/mihnita/colorlog/log4j/JAnsiColorConsoleAppender.class:  compiled Java class data, version 49.0 (Java 1.5)
target/color-loggers-1.0.5.jar/com/mihnita/colorlog/logback/ColorPatternLayoutEncoder.class:  compiled Java class data, version 49.0 (Java 1.5)
target/color-loggers-1.0.5.jar/com/mihnita/colorlog/logback/CustomHighlightingCompositeConverter.class:  compiled Java class data, version 49.0 (Java 1.5)

Comment in Commit:

* Numerous Fixes for Color:
  - Make Color Schema work on Black and White Backgrounds.
  - Make Color Scheme Uniform Rainbow.
* Build JAR for Java 1.5 and Above.